### PR TITLE
Stylistic enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ List of commercial companies and non-profit organizations using Zig in productio
 - [Axiom](https://axiom.co/) — [GitHub](https://github.com/axiomhq/zig-hyperloglog)
 - [Bun](https://bun.sh/) — [GitHub](https://github.com/oven-sh/bun)
 - [DNEG](https://www.dneg.com/) — [GitHub](https://github.com/dneg) | [Video presentation 1](https://www.youtube.com/watch?v=xUInj_nEcEg) | [Video presentation 2](https://www.youtube.com/watch?v=MhzWE2z4fjA)
+- [RDDL Foundation](https://www.rddl.io/) — [GitHub](https://github.com/rddl-network/libocc)
 - [Spiral](https://spiraldb.com) — [GitHub](https://github.com/spiraldb)
 - [Starknet](https://www.starknet.io/en) — [GitHub](https://github.com/keep-starknet-strange/ziggy-starkdust)
 - [Syndica](https://syndica.io/) — [Blog post](https://blog.syndica.io/introducing-sig-by-syndica-an-rps-focused-solana-validator-client-written-in-zig/)
@@ -28,6 +29,7 @@ List of commercial companies and non-profit organizations using Zig in productio
 - [Midstall Software](https://midstall.com/) — [GitHub](https://github.com/MidstallSoftware)
 - [Roc Programming Language Foundation](https://foundation.roc-lang.org/) — [GitHub](https://github.com/roc-lang/roc/tree/main/crates/compiler/builtins/bitcode)
 - [Zig Software Foundation](https://ziglang.org/zsf/) — [GitHub](https://github.com/ziglang)
+- [Zig Tools Open Collective](https://opencollective.com/zigtools) — [GitHub](https://github.com/zigtools)
 
 ## Inspirations
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
 # Zig Companies
 
-A list of companies using Zig in production. ([discussion](https://ziggit.dev/t/list-of-companies-using-zig-in-production/4084))
+List of commercial companies and non-profit organizations using Zig in production ([Ziggit discussion](https://ziggit.dev/t/list-of-companies-using-zig-in-production/4084)).
 
-- Bun: https://github.com/oven-sh/bun
-- TigerBeetle: https://github.com/tigerbeetle/tigerbeetle
-- Uber: https://jakstys.lt/2022/how-uber-uses-zig/
-- Vercel: https://vercel.com/blog/how-we-continued-porting-turborepo-to-rust
-- Tuple: https://github.com/tupleapp
-- Fulcrum: https://github.com/fulcrum-so
-- Turso: https://turso.tech/blog/zig-helped-us-move-data-to-the-edge-here-are-our-impressions-67d3a9c45af4
-- Ameli: https://github.com/bfactory-ai/zignal
-- Axiom: https://github.com/axiomhq/zig-hyperloglog
-- Midstall Software: https://github.com/MidstallSoftware
-- ZML: https://github.com/zml
-- DENG: https://github.com/dneg ([1](https://www.youtube.com/watch?v=xUInj_nEcEg) [2](https://www.youtube.com/watch?v=MhzWE2z4fjA))
-- Defold: https://github.com/defold ([1](https://defold.com/presentations/zigmeetup_sthlm_3_v2.pdf))
-- Syndica: https://blog.syndica.io/introducing-sig-by-syndica-an-rps-focused-solana-validator-client-written-in-zig/
-- StarkNet: https://www.starknet.io/en [1](https://github.com/keep-starknet-strange/ziggy-starkdust)
+## Commercial companies using the Zig programming language in production
 
-## Not companies but related
+- [Ameli](https://ameli.co.kr/) — [GitHub](https://github.com/bfactory-ai/zignal)
+- [Axiom](https://axiom.co/) — [GitHub](https://github.com/axiomhq/zig-hyperloglog)
+- [Bun](https://bun.sh/) — [GitHub](https://github.com/oven-sh/bun)
+- [DNEG](https://www.dneg.com/) — [GitHub](https://github.com/dneg) | [Video presentation 1](https://www.youtube.com/watch?v=xUInj_nEcEg) | [Video presentation 2](https://www.youtube.com/watch?v=MhzWE2z4fjA)
+- [Fulcrum Labs](https://fulcrum.so/) — [GitHub](https://github.com/fulcrum-so)
+- [Starknet](https://www.starknet.io/en) — [GitHub](https://github.com/keep-starknet-strange/ziggy-starkdust)
+- [Syndica](https://syndica.io/) — [Blog post](https://blog.syndica.io/introducing-sig-by-syndica-an-rps-focused-solana-validator-client-written-in-zig/)
+- [TigerBeetle](https://tigerbeetle.com/) — [GitHub](https://github.com/tigerbeetle/tigerbeetle)
+- [Tuple](https://tuple.app/) — [GitHub](https://github.com/tupleapp)
+- [Turso](https://turso.tech/blog/zig-helped-us-move-data-to-the-edge-here-are-our-impressions-67d3a9c45af4) — [GitHub](https://github.com/tursodatabase/pg_turso)
+- [ZML](https://zml.ai/) — [GitHub](https://github.com/zml)
 
-- Mach: https://github.com/hexops
-- Roc: https://github.com/roc-lang/roc/tree/main/crates/compiler/builtins/bitcode
-- Zig Foundation: https://ziglang.org/zsf/ employs couple of developers
+## Commercial companies using the Zig build system in production
 
-## Inspired by
+- [Uber](https://www.uber.com/) — [Video presentation](https://www.youtube.com/watch?v=SCj2J3HcEfc) | [Blog post](https://jakstys.lt/2022/how-uber-uses-zig/)
+- [Vercel](https://vercel.com/) — [Blog post](https://vercel.com/blog/how-we-continued-porting-turborepo-to-rust)
 
-- https://twitter.com/natalievais/status/1769845939605250084
-- https://github.com/ImplFerris/rust-in-production
-- https://github.com/omarabid/rust-companies
+## Non-profit organizations using Zig in production
+
+- [Defold](https://defold.com/) — [GitHub](https://github.com/defold) | [Presentation slides](https://defold.com/presentations/zigmeetup_sthlm_3_v2.pdf)
+- [Hexops](https://hexops.com/) — [GitHub](https://github.com/hexops)
+- [Midstall Software](https://midstall.com/) — [GitHub](https://github.com/MidstallSoftware)
+- [Roc Programming Language Foundation](https://foundation.roc-lang.org/) — [GitHub](https://github.com/roc-lang/roc/tree/main/crates/compiler/builtins/bitcode)
+- [Zig Software Foundation](https://ziglang.org/zsf/) — [GitHub](https://github.com/ziglang)
+
+## Inspirations
+
+- [Natalie Vais' Zig Companies Twitter post](https://twitter.com/natalievais/status/1769845939605250084)
+- [Rust in Production GitHub repo](https://github.com/ImplFerris/rust-in-production)
+- [Rust Companies GitHub repo](https://github.com/omarabid/rust-companies)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ List of commercial companies and non-profit organizations using Zig in productio
 - [Axiom](https://axiom.co/) — [GitHub](https://github.com/axiomhq/zig-hyperloglog)
 - [Bun](https://bun.sh/) — [GitHub](https://github.com/oven-sh/bun)
 - [DNEG](https://www.dneg.com/) — [GitHub](https://github.com/dneg) | [Video presentation 1](https://www.youtube.com/watch?v=xUInj_nEcEg) | [Video presentation 2](https://www.youtube.com/watch?v=MhzWE2z4fjA)
-- [Fulcrum Labs](https://fulcrum.so/) — [GitHub](https://github.com/fulcrum-so)
+- [Spiral](https://spiraldb.com) — [GitHub](https://github.com/spiraldb)
 - [Starknet](https://www.starknet.io/en) — [GitHub](https://github.com/keep-starknet-strange/ziggy-starkdust)
 - [Syndica](https://syndica.io/) — [Blog post](https://blog.syndica.io/introducing-sig-by-syndica-an-rps-focused-solana-validator-client-written-in-zig/)
 - [TigerBeetle](https://tigerbeetle.com/) — [GitHub](https://github.com/tigerbeetle/tigerbeetle)


### PR DESCRIPTION
- Separated companies into "commercial" vs "non-profits" sections
- Separated commercial companies into "using the Zig programming language" vs "using the Zig build system" sections
- Added company landing page links
- Specified GitHub and other additional resource links
- Corrected typo: "DENG" => "DNEG"
- Sorted entries alphabetically
- Renamed Fulcrum Labs to Spiral
- Added RDDL Foundation and Zig Tools Open Collective